### PR TITLE
Add Pilot3 Website Home Page Latest News Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ The website is divide into 4 sections that will walk you through our efforts:
 1. **Conferences** - Proceedings from different conferences on Pilot Submissions
 1. **FDA Feedback** - Specific feedback from FDA on this Submission
 
+
+## Latest News
+
+* [First Publicly Available R-Based Submission Package Submitted to FDA (Pilot 3)](https://www.r-consortium.org/announcement/2023/09/11/first-publicly-available-r-based-submission-package-submitted-to-fda-pilot-3)
+
+* [Novo Nordisk's Journey to an R based FDA Submission](https://www.youtube.com/watch?v=t33dS17QHuA)
+    - *Data scientists at Novo Nordisk, a leading pharmaceutical company in diabetes, obesity, and other chronic diseases, share details of their first FDA submission package featuring outputs and* [ADaM datasets](https://www.cdisc.org/standards/foundational/adam) *written exclusively in R.*
+
 ## Get in Touch
 
 Don't be shy!  We like to chat about R and Submissions. Find us on [pharmaverse slack](https://pharmaverse.slack.com/archives/C030EB2M4GM)
-
-


### PR DESCRIPTION
Added a Latest News section to the Pilot 3 website home page and two bullets: [i]the R Consortium Blog Announcement page, and [ii]a blurb with YouTube link about the Novo Nordisk submission journey.