### PR TITLE
Add website link to the February 2, 2024 R Consortium WG Meeting Minu…

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -69,14 +69,16 @@ navbar:
       menu:
       - text: -------
       - text: "R Consortium WG Meeting Minutes"
-      - text: October 2023
-        href: https://rconsortium.github.io/submissions-wg/minutes/2023-10-06/
-      - text: November 2023
-        href: https://rconsortium.github.io/submissions-wg/minutes/2023-11-03/
-      - text: December 2023
-        href: https://rconsortium.github.io/submissions-wg/minutes/2023-12-01/
+      - text: February 2024
+        href: https://rconsortium.github.io/submissions-wg/minutes/2024-02-02/
       - text: January 2024
         href: https://rconsortium.github.io/submissions-wg/minutes/2024-01-05/
+      - text: December 2023
+        href: https://rconsortium.github.io/submissions-wg/minutes/2023-12-01/
+      - text: November 2023
+        href: https://rconsortium.github.io/submissions-wg/minutes/2023-11-03/
+      - text: October 2023
+        href: https://rconsortium.github.io/submissions-wg/minutes/2023-10-06/
       - text: -------
       - text: "Pilot3 Submission Issues Compilation"
       - text: January 2024 FDA Feedback Summary


### PR DESCRIPTION
…tes menu under Section 1. Arrange links to WG Meeting Minutes recordings in descending order (newest to oldest).