### PR TITLE
Pilot3 Website Update with link to R Consortium March 2024 Meeting Minutes

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -71,6 +71,8 @@ navbar:
       menu:
       - text: -------
       - text: "R Consortium WG Meeting Minutes"
+      - text: March 2024
+        href: https://rconsortium.github.io/submissions-wg/minutes/2024-03-01/
       - text: February 2024
         href: https://rconsortium.github.io/submissions-wg/minutes/2024-02-02/
       - text: January 2024


### PR DESCRIPTION
Minutes include Regulatory Feedback about Pilot3, updates about Pilot4, other R Consortium WG topics.