### PR TITLE
Tidying .Rbuildignore removing {pilot1wrappers} references 

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,9 +2,6 @@
 ^renv\.lock$
 ^.*\.Rproj$
 ^\.Rproj\.user$
-^pilot1wrappers\.Rcheck$
-^pilot1wrappers.*\.tar\.gz$
-^pilot1wrappers.*\.tgz$
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$


### PR DESCRIPTION
The {pilot3utils} proprietary package has been separated successfully in the main assembly core. thx.